### PR TITLE
fix: changed template name in azure.yml

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -2,15 +2,15 @@
 # metadata:
 #     template: azd-init@1.11.1
 environment:
-  name: conversation-knowledge-mining
+  name: data-agents-fabric-knowledge-mining
   location: eastus
-name: conversation-knowledge-mining
+name: data-agents-fabric-knowledge-mining
 
 requiredVersions:
   azd: ">= 1.15.0"
 
 metadata:
-  template: conversation-knowledge-mining@1.0
+  template: data-agents-fabric-knowledge-mining@1.0
 
 hooks:
   postprovision:


### PR DESCRIPTION
This pull request updates the `azure.yaml` configuration file to reflect a renaming of the project and its associated metadata. The changes ensure consistency in naming conventions across the environment and metadata sections.

### Updates to project naming:

- Updated the environment name from `conversation-knowledge-mining` to `data-agents-fabric-knowledge-mining` to align with the new project naming convention. (`[azure.yamlL5-R13](diffhunk://#diff-1ba5bd52036276068bc787a1be3dfa49aa920317ab02fa460c99246a78e588f3L5-R13)`)
- Updated the metadata template from `conversation-knowledge-mining@1.0` to `data-agents-fabric-knowledge-mining@1.0` for consistency with the new project name. (`[azure.yamlL5-R13](diffhunk://#diff-1ba5bd52036276068bc787a1be3dfa49aa920317ab02fa460c99246a78e588f3L5-R13)`)