### PR TITLE
fix: updated the backend logic for auth and non auth users for CRUD operations

### DIFF
--- a/src/api/history_sql.py
+++ b/src/api/history_sql.py
@@ -380,10 +380,6 @@ async def delete_conversation(user_id: str, conversation_id: str) -> bool:
             logger.warning("No conversation_id found, cannot delete conversation.")
             return False
 
-        if user_id is None:
-            logger.warning("User ID is None, cannot delete conversation %s.", conversation_id)
-            return False
-
         query = "SELECT userId, conversation_id FROM hst_conversations where conversation_id = ?"
         conversation = await run_query_params(query, (conversation_id,))        
         if not conversation or len(conversation) == 0:
@@ -391,19 +387,30 @@ async def delete_conversation(user_id: str, conversation_id: str) -> bool:
             return False
 
         # If the userId in the conversation does not match the user_id, deny access
-        if conversation and conversation[0]["userId"] != user_id:
+        if user_id and conversation and conversation[0]["userId"] != user_id:
             logger.warning(
                 "User %s does not have permission to delete %s.", user_id, conversation_id)
             return False
-        # Prepare parameters for deletion
-        params = (user_id, conversation_id)
-        # Delete associated messages first (if applicable)
-        query_m = "DELETE FROM hst_conversation_messages where userId = ?  and conversation_id = ?"
-        await run_nonquery_params(query_m, params)
+        
+        if user_id:
+            # Prepare parameters for deletion
+            params = (user_id, conversation_id)
+            # Delete associated messages first (if applicable)
+            query_m = "DELETE FROM hst_conversation_messages where userId = ?  and conversation_id = ?"
+            await run_nonquery_params(query_m, params)
 
-        # Delete the conversation itself
-        query_m = "DELETE FROM hst_conversations where userId = ?  and conversation_id = ?"
-        await run_nonquery_params(query_m, params)
+            # Delete the conversation itself
+            query_m = "DELETE FROM hst_conversations where userId = ?  and conversation_id = ?"
+            await run_nonquery_params(query_m, params)
+        else:
+            params = (conversation_id)
+            # Delete associated messages first (if applicable)
+            query_m = "DELETE FROM hst_conversation_messages where conversation_id = ?"
+            await run_nonquery_params(query_m, params)
+
+            # Delete the conversation itself
+            query_c = "DELETE FROM hst_conversations where conversation_id = ?"
+            await run_nonquery_params(query_c, params)
 
         return True
 
@@ -423,17 +430,22 @@ async def delete_all_conversations(user_id: str) -> bool:
         bool: True if all conversations were successfully deleted, False otherwise.
     """
     try:
-        if user_id is None:
-            logger.warning("User ID is None, cannot delete conversations.")
-            return False
+        
+        if user_id:
+            # Delete all associated messages
+            query_m = "DELETE FROM hst_conversation_messages WHERE userId = ?"
+            messages_result = await run_nonquery_params(query_m, (user_id,))
 
-        # Delete all associated messages
-        query_m = "DELETE FROM hst_conversation_messages WHERE userId = ?"
-        messages_result = await run_nonquery_params(query_m, (user_id,))
+            # Delete all conversations
+            query_c = "DELETE FROM hst_conversations WHERE userId = ?"
+            conversations_result = await run_nonquery_params(query_c, (user_id,))
+        else:
+            # If user_id is None, delete all conversations without user filtering
+            query_m = "DELETE FROM hst_conversation_messages"
+            messages_result = await run_nonquery_params(query_m)
 
-        # Delete all conversations
-        query_c = "DELETE FROM hst_conversations WHERE userId = ?"
-        conversations_result = await run_nonquery_params(query_c, (user_id,))
+            query_c = "DELETE FROM hst_conversations"
+            conversations_result = await run_nonquery_params(query_c)
 
         # Verify deletion was successful
         if messages_result is False or conversations_result is False:
@@ -463,10 +475,6 @@ async def rename_conversation(user_id: str, conversation_id, title) -> bool:
         if not conversation_id:
             raise ValueError("No conversation_id found")
 
-        if user_id is None:
-            logger.warning("User ID is None, cannot rename title of the conversation %s.", conversation_id)
-            return False
-
         if title is None:
             logger.warning("Title is None, cannot rename title of the conversation %s.", conversation_id)
             return False
@@ -479,15 +487,19 @@ async def rename_conversation(user_id: str, conversation_id, title) -> bool:
             logger.warning("Conversation %s not found.", conversation_id)
             return False
 
-        # Check if the user has permission to delete it
-        if conversation and conversation[0]["userId"] != user_id:
+        # Check if the user has permission to rename it
+        if user_id and conversation and conversation[0]["userId"] != user_id:
             logger.warning(
-                "User %s does not have permission to delete %s.", user_id, conversation_id)
+                "User %s does not have permission to rename %s.", user_id, conversation_id)
             return False
 
         # Update the title of the conversation
-        query_t = "UPDATE hst_conversations SET title = ? WHERE userId = ?  and conversation_id = ?"
-        await run_nonquery_params(query_t, (title, user_id, conversation_id))
+        if user_id:
+            query_t = "UPDATE hst_conversations SET title = ? WHERE userId = ?  and conversation_id = ?"
+            await run_nonquery_params(query_t, (title, user_id, conversation_id))
+        else:
+            query_t = "UPDATE hst_conversations SET title = ? WHERE conversation_id = ?"
+            await run_nonquery_params(query_t, (title, conversation_id))
 
         return True
     except Exception as e:
@@ -580,9 +592,9 @@ async def create_conversation(user_id, title="", conversation_id=None):
         Exception: If an error occurs during conversation creation.
     """
     try:        
-        if not user_id:
-            logger.warning("No User ID found, cannot create conversation.")
-            return None
+        # if not user_id:
+        #     logger.warning("No User ID found, cannot create conversation.")
+        #     return None
 
         if not conversation_id:
             logger.warning("No conversation_id found, generating a new one.")
@@ -621,9 +633,9 @@ async def create_message(uuid, conversation_id, user_id, input_message: dict):
         Exception: If an error occurs during message creation.
     """
     try:
-        if not user_id:
-            logger.warning("No User ID found, cannot create message.")
-            return None
+        # if not user_id:
+        #     logger.warning("No User ID found, cannot create message.")
+        #     return None
 
         if not conversation_id:
             logger.warning("No conversation_id found, cannot create conversation message.")
@@ -703,9 +715,9 @@ async def update_conversation(user_id: str, request_json: dict):
         conversation_id = request_json.get("conversation_id")
         messages = request_json.get("messages", [])
 
-        if not user_id:
-            logger.warning("No User ID found, cannot update conversation.")
-            return None
+        # if not user_id:
+        #     logger.warning("No User ID found, cannot update conversation.")
+        #     return None
 
         # conversation = None
         query = "SELECT * FROM hst_conversations where conversation_id = ?"
@@ -984,12 +996,12 @@ async def delete_all_conversations_endpoint(request: Request):
             request_headers=request.headers)
         user_id = authenticated_user["user_principal_id"]
 
-        if not user_id:
-            track_event_if_configured("DeleteAllConversationsValidationError", {
-                "error": "user_id is missing",
-                "user_id": user_id
-            })
-            raise HTTPException(status_code=400, detail="user_id is required")
+        # if not user_id:
+        #     track_event_if_configured("DeleteAllConversationsValidationError", {
+        #         "error": "user_id is missing",
+        #         "user_id": user_id
+        #     })
+        #     raise HTTPException(status_code=400, detail="user_id is required")
         # Get all user conversations
         conversations = await get_conversations(user_id, offset=0, limit=None)
         if not conversations:


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

This pull request refactors several conversation-related functions in `src/api/history_sql.py` to allow operations to proceed even when `user_id` is `None`. This enables system-wide actions, such as deleting or updating all conversations regardless of user ownership. The changes also improve permission checks and streamline error handling for cases where `user_id` may be absent.

**Permission and access control changes:**

* Updated permission checks in `delete_conversation` and `rename_conversation` to only enforce user ownership if `user_id` is provided, allowing system-level operations when `user_id` is `None`. [[1]](diffhunk://#diff-200c2aa6d7b10a95af0f8810b36403185e80b6ee71ed0cf822b5debbcd0ffb49L383-R395) [[2]](diffhunk://#diff-200c2aa6d7b10a95af0f8810b36403185e80b6ee71ed0cf822b5debbcd0ffb49L466-L469) [[3]](diffhunk://#diff-200c2aa6d7b10a95af0f8810b36403185e80b6ee71ed0cf822b5debbcd0ffb49L482-R502)
* Modified deletion logic in `delete_conversation` and `delete_all_conversations` to support deleting conversations and messages without user filtering if `user_id` is `None`. [[1]](diffhunk://#diff-200c2aa6d7b10a95af0f8810b36403185e80b6ee71ed0cf822b5debbcd0ffb49R405-R413) [[2]](diffhunk://#diff-200c2aa6d7b10a95af0f8810b36403185e80b6ee71ed0cf822b5debbcd0ffb49L426-R448)

**Error handling and validation updates:**

* Commented out strict validation for missing `user_id` in several functions (`create_conversation`, `create_message`, `update_conversation`, and the delete-all endpoint), allowing these operations to proceed even if `user_id` is not provided. [[1]](diffhunk://#diff-200c2aa6d7b10a95af0f8810b36403185e80b6ee71ed0cf822b5debbcd0ffb49L583-R597) [[2]](diffhunk://#diff-200c2aa6d7b10a95af0f8810b36403185e80b6ee71ed0cf822b5debbcd0ffb49L624-R638) [[3]](diffhunk://#diff-200c2aa6d7b10a95af0f8810b36403185e80b6ee71ed0cf822b5debbcd0ffb49L706-R720) [[4]](diffhunk://#diff-200c2aa6d7b10a95af0f8810b36403185e80b6ee71ed0cf822b5debbcd0ffb49L987-R1004)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

