### PR TITLE
fix:  Asking for a chart tells used a JSON response that cannot, should be plain sentence response

### DIFF
--- a/src/App/src/components/Chat/Chat.tsx
+++ b/src/App/src/components/Chat/Chat.tsx
@@ -615,9 +615,17 @@ const Chat: React.FC<ChatProps> = ({
               parsedChartResponse?.error ||
               parsedChartResponse?.choices[0]?.messages[0]?.content
             ) {
-              const errorMsg =
-                parsedChartResponse?.error ||
-                parsedChartResponse?.choices[0]?.messages[0]?.content;
+              let content = parsedChartResponse?.choices[0]?.messages[0]?.content;
+              let displayContent = content;
+              try {
+                const parsed = typeof content === "string" ? JSON.parse(content) : content;
+                if (parsed && typeof parsed === "object" && "answer" in parsed) {
+                  displayContent = parsed.answer;
+                }
+              } catch {
+                displayContent = content;
+              }
+              const errorMsg = parsedChartResponse?.error || displayContent;
               const errorMessage: ChatMessage = {
                 id: generateUUIDv4(),
                 role: ERROR,


### PR DESCRIPTION
## Purpose
 Asking for a chart tells used a JSON response that cannot, should be plain sentence response
 
 bug: https://dev.azure.com/CSACTOSOL/DATA%20-%20ACCL%20-%20Fabric%20Agentic%20AI/_workitems/edit/23442

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [ ] I have validated the deployment process successfully and all services are running as expected with this change.

