### PR TITLE
fix: update default answer message for empty results in SQL plugin

### DIFF
--- a/src/api/chat.py
+++ b/src/api/chat.py
@@ -135,7 +135,7 @@ class ChatWithDataPlugin:
             if isinstance(answer_raw, str):
                 answer = answer_raw[:20000] if len(answer_raw) > 20000 else answer_raw
             else:
-                answer = answer_raw or ""
+                answer = answer_raw or "No results found."
 
             # Clean up
             project_client.agents.threads.delete(thread_id=thread.id)


### PR DESCRIPTION
This pull request makes a small but important change to the `get_sql_response` function in `src/api/chat.py`. The change improves the handling of empty or missing SQL query results by returning a more informative message.

* When no results are found from a SQL query, the function now returns `"No results found."` instead of an empty string.