### PR TITLE
chore: update post-deployment scripts to run with relative paths

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -21,9 +21,9 @@ hooks:
 
         # Build the exact command string (quoted to survive spaces)
         Write-Host "`nRun the following 2 commands in the bash terminal to create agents and fabric items respectively:"
-        Write-Host "bash ./run_create_agents_scripts.sh" -ForegroundColor Cyan
+        Write-Host "bash ./infra/scripts/agent_scripts/run_create_agents_scripts.sh" -ForegroundColor Cyan
 
-        Write-Host "`nbash ./run_fabric_items_scripts.sh <fabric_workspace_id>" -ForegroundColor Cyan   
+        Write-Host "`nbash ./infra/scripts/fabric_scripts/run_fabric_items_scripts.sh <fabric_workspace_id>" -ForegroundColor Cyan
 
       shell: pwsh
       continueOnError: false
@@ -34,8 +34,8 @@ hooks:
         echo $WEB_APP_URL
 
         echo "\nRun the following 2 commands in the bash terminal to create agents and fabric items respectively:"
-        echo "bash ./run_create_agents_scripts.sh"
-        echo "\nbash ./run_fabric_items_scripts.sh <fabric_workspace_id>"
+        echo "bash ./infra/scripts/agent_scripts/run_create_agents_scripts.sh"
+        echo "\nbash ./infra/scripts/fabric_scripts/run_fabric_items_scripts.sh <fabric_workspace_id>"
 
       shell: sh
       continueOnError: false

--- a/documents/DeploymentGuide.md
+++ b/documents/DeploymentGuide.md
@@ -177,8 +177,8 @@ Once you've opened the project in [Codespaces](#github-codespaces), [Dev Contain
     - If you encounter an error or timeout during deployment, changing the location may help, as there could be availability constraints for the resources.
 
 5. Once the deployment has completed successfully, copy the 2 bash commands from the terminal (ex. 
-`bash ./run_create_agents_scripts.sh` and
-`bash ./run_fabric_items_scripts.sh <fabric-workspaceId>`) for later use.
+`bash ./infra/scripts/agent_scripts/run_create_agents_scripts.sh` and
+`bash ./infra/scripts/fabric_scripts/run_fabric_items_scripts.sh <fabric-workspaceId>`) for later use.
 
 > **Note**: if you are running this deployment in GitHub Codespaces or VS Code Dev Container skip to step 7. 
 
@@ -197,43 +197,29 @@ Once you've opened the project in [Codespaces](#github-codespaces), [Dev Contain
   az login
   ```
 
-8. Open a Git Bash terminal and navigate to the agent_scripts folder
-  ```shell
-  cd infra/scripts/agent_scripts
-  ```
-
-9. Run the bash script from the output of the azd deployment. The script will look like the following:
+8. Run the bash script from the output of the azd deployment. The script will look like the following:
   ```Shell
-  bash ./run_create_agents_scripts.sh
+  bash ./infra/scripts/agent_scripts/run_create_agents_scripts.sh
   ```
 
   If you don't have azd env then you need to pass parameters along with the command. Then the command will look like the following:
   ```Shell
-  bash ./run_create_agents_scripts.sh <project-endpoint> <solution-name> <gpt-model-name> <ai-foundry-resource-id> <api-app-name> <resource-group>
+  bash ./infra/scripts/agent_scripts/run_create_agents_scripts.sh <project-endpoint> <solution-name> <gpt-model-name> <ai-foundry-resource-id> <api-app-name> <resource-group>
   ```
 
-10. In your Git Bash terminal, navigate to the fabric_scripts folder
-  ```shell
-  cd ..
-  ```
-
-  ```shell
-  cd fabric_scripts
-  ```
-
-11. Run the bash script from the output of the azd deployment. Replace the <fabric-workspaceId> with your Fabric workspace Id created in the previous steps. The script will look like the following:
+9. Run the bash script from the output of the azd deployment. Replace the <fabric-workspaceId> with your Fabric workspace Id created in the previous steps. The script will look like the following:
   ```Shell
-  bash ./run_fabric_items_scripts.sh <fabric-workspaceId>
+  bash ./infra/scripts/fabric_scripts/run_fabric_items_scripts.sh <fabric-workspaceId>
   ```
 
   If you don't have azd env then you need to pass parameters along with the command. Then the command will look like the following:
   ```Shell
-  bash ./run_fabric_items_scripts.sh <fabric-workspaceId> <solutionname> <ai-foundry-name> <backend-api-mid-principal> <backend-api-mid-client> <api-app-name> <resourcegroup>
+  bash ./infra/scripts/fabric_scripts/run_fabric_items_scripts.sh <fabric-workspaceId> <solutionname> <ai-foundry-name> <backend-api-mid-principal> <backend-api-mid-client> <api-app-name> <resourcegroup>
   ```
 
-12. Once the script has run successfully, go to the deployed resource group, find the App Service, and get the app URL from `Default domain`.
+10. Once the script has run successfully, go to the deployed resource group, find the App Service, and get the app URL from `Default domain`.
 
-13. If you are done trying out the application, you can delete the resources by running `azd down`.
+11. If you are done trying out the application, you can delete the resources by running `azd down`.
 
 
 ## Post Deployment Steps

--- a/infra/scripts/agent_scripts/run_create_agents_scripts.sh
+++ b/infra/scripts/agent_scripts/run_create_agents_scripts.sh
@@ -81,7 +81,7 @@ else
 fi
 
 
-requirementFile="requirements.txt"
+requirementFile="infra/scripts/agent_scripts/requirements.txt"
 
 # Download and install Python requirements
 python -m pip install --upgrade pip
@@ -90,7 +90,7 @@ python -m pip install --quiet -r "$requirementFile"
 # Execute the Python scripts
 echo "Running Python agents creation script..."
 # python 01_create_agents.py
-eval $(python 01_create_agents.py --ai_project_endpoint="$projectEndpoint" --solution_name="$solutionName" --gpt_model_name="$gptModelName")
+eval $(python infra/scripts/agent_scripts/01_create_agents.py --ai_project_endpoint="$projectEndpoint" --solution_name="$solutionName" --gpt_model_name="$gptModelName")
 
 echo "Agents creation completed."
 

--- a/infra/scripts/fabric_scripts/create_fabric_items.py
+++ b/infra/scripts/fabric_scripts/create_fabric_items.py
@@ -76,7 +76,7 @@ directory_client = file_system_client.get_directory_client(f"{data_path}/{folder
 print('uploading files')
 # upload audio files
 file_client = directory_client.get_file_client("data/" + 'tables.json')
-with open(file='sql_files/tables.json', mode="rb") as data:
+with open(file='infra/scripts/fabric_scripts/sql_files/tables.json', mode="rb") as data:
         # print('data', data)
     file_client.upload_data(data, overwrite=True)
 
@@ -186,7 +186,7 @@ def get_fabric_db_connection():
 conn = get_fabric_db_connection()
 cursor = conn.cursor()
 print(cursor)
-sql_filename = 'sql_files/data_sql.sql'
+sql_filename = 'infra/scripts/fabric_scripts/sql_files/data_sql.sql'
 with open(sql_filename, 'r', encoding='utf-8') as f:
     sql_script = f.read()
     cursor.execute(sql_script)
@@ -195,7 +195,7 @@ cursor.commit()
 
 import json
 
-file_path = "sql_files/tables.json"
+file_path = "infra/scripts/fabric_scripts/sql_files/tables.json"
 
 time.sleep(120)
 with open(file_path, "r", encoding="utf-8") as f:

--- a/infra/scripts/fabric_scripts/run_fabric_items_scripts.sh
+++ b/infra/scripts/fabric_scripts/run_fabric_items_scripts.sh
@@ -102,15 +102,14 @@ fi
 # sed -i "s/kv_to-be-replaced/${keyvaultName}/g" "create_fabric_items.py"
 # sed -i "s/solutionName_to-be-replaced/${solutionName}/g" "create_fabric_items.py"
 # sed -i "s/workspaceId_to-be-replaced/${fabricWorkspaceId}/g" "create_fabric_items.py"
-
-python -m pip install -r requirements.txt --quiet
+python -m pip install -r infra/scripts/fabric_scripts/requirements.txt --quiet
 
 # Run Python unbuffered so prints show immediately.
 tmp="$(mktemp)"
 cleanup() { rm -f "$tmp"; }
 trap cleanup EXIT
 
-python -u create_fabric_items.py --workspaceId "$fabricWorkspaceId" --solutionname "$solutionName" --backend_app_pid "$backend_app_pid" --backend_app_uid "$backend_app_uid" --exports-file "$tmp"
+python -u infra/scripts/fabric_scripts/create_fabric_items.py --workspaceId "$fabricWorkspaceId" --solutionname "$solutionName" --backend_app_pid "$backend_app_pid" --backend_app_uid "$backend_app_uid" --exports-file "$tmp"
 
 source "$tmp"
 


### PR DESCRIPTION
## Purpose

This pull request updates script and documentation references throughout the deployment workflow to use the correct relative paths for agent and fabric scripts. The main goal is to ensure all commands, file references, and documentation consistently point to the scripts and resources within the `infra/scripts/agent_scripts` and `infra/scripts/fabric_scripts` directories, improving reliability and reducing confusion for users.

**Documentation and command updates:**
- Updated all deployment guide instructions and output messages to reference the correct script locations (`infra/scripts/agent_scripts` and `infra/scripts/fabric_scripts`) instead of the project root, ensuring users run scripts from the right directories. [[1]](diffhunk://#diff-2afa876cbd4555ebfa7f423b650916642673e68d9d91b430ba3c72539e127ae5L180-R181) [[2]](diffhunk://#diff-2afa876cbd4555ebfa7f423b650916642673e68d9d91b430ba3c72539e127ae5L200-R222) [[3]](diffhunk://#diff-1ba5bd52036276068bc787a1be3dfa49aa920317ab02fa460c99246a78e588f3L24-R26) [[4]](diffhunk://#diff-1ba5bd52036276068bc787a1be3dfa49aa920317ab02fa460c99246a78e588f3L37-R38)

**Script path corrections:**
- Modified `run_create_agents_scripts.sh` and `run_fabric_items_scripts.sh` to use the correct paths for requirements files, Python scripts, and data files within their respective directories, preventing file-not-found errors during execution. [[1]](diffhunk://#diff-bfb65ac3d115f97bd3545f894d6f3e002c9b2b72071df87a08ae4af8d8cbe517L84-R84) [[2]](diffhunk://#diff-bfb65ac3d115f97bd3545f894d6f3e002c9b2b72071df87a08ae4af8d8cbe517L93-R93) [[3]](diffhunk://#diff-99209a4d125678f1546b9d6c8cfbb93d74792b208067b924fbb451d893883d26L105-R112)

**Python file reference fixes:**
- Updated file paths in `create_fabric_items.py` to correctly locate `tables.json` and `data_sql.sql` within the `infra/scripts/fabric_scripts/sql_files` directory, ensuring successful file operations during deployment. [[1]](diffhunk://#diff-75cd896750e5d33b77d9b9ad1d62155794e533d0d0dac16cd122ea472f8df1cfL79-R79) [[2]](diffhunk://#diff-75cd896750e5d33b77d9b9ad1d62155794e533d0d0dac16cd122ea472f8df1cfL189-R189) [[3]](diffhunk://#diff-75cd896750e5d33b77d9b9ad1d62155794e533d0d0dac16cd122ea472f8df1cfL198-R198)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

<img width="1178" height="650" alt="image" src="https://github.com/user-attachments/assets/b45acac4-f73d-4509-b80e-31927afc2b70" />
<img width="1145" height="239" alt="image" src="https://github.com/user-attachments/assets/6659884e-4142-4fcc-88e6-d651698c5e33" />
<img width="1035" height="339" alt="image" src="https://github.com/user-attachments/assets/01ad9288-f37f-4923-8478-ca07973d9559" />


